### PR TITLE
Improve angle types doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,25 +16,23 @@ Using simple floating point numbers to store an angle value is error-prone : you
 ```rust
 use angulus::*;
 
-fn main() {
-    // Create an angle of 90°.
-    let alpha = 90.0_f32.deg();
+// Create an angle of 90°.
+let alpha = 90.0_f32.deg();
 
-    // Create an angle of π/4 rad (45°).
-    let beta = Angle::RAD_FRAC_PI_4;
+// Create an angle of π/4 rad (45°).
+let beta = Angle::RAD_FRAC_PI_4;
 
-    // Add the two angle without worrying about units.
-    let gamma = alpha + beta;
+// Add the two angle without worrying about units.
+let gamma = alpha + beta;
 
-    // Print the result.
-    println!(
-        "The cosine of {} is {}",
-        units::Degrees(gamma), // The angle is wrapped to display the value in degrees.
-        gamma.cos()            // Compute the cosine without worrying about units.
-    );
+// Print the result.
+println!(
+    "The cosine of {} is {}",
+    units::Degrees(gamma), // The angle is wrapped to display the value in degrees.
+    gamma.cos()            // Compute the cosine without worrying about units.
+);
 
-    // Output : The cosine of 135° is -0.70710677
-}
+// Output : The cosine of 135° is -0.70710677
 ```
 
 ## Features

--- a/src/angle.rs
+++ b/src/angle.rs
@@ -5,11 +5,37 @@ use crate::{
     float::Float, forward_ref_binop, forward_ref_op_assign, forward_ref_unop, AngleUnbounded,
 };
 
-/// Represents the canonical value of an angle.
-///
-/// The value is stored in the range `(-π, π]`.
+/// Represents a point on the circle as an unit agnostic angle.
 ///
 /// The parameter `F` is the floating-point type used to store the value.
+///
+/// ## Behaviour
+///
+/// Two different values of the same point on the circle are the same [`Angle`] :
+///
+/// ```
+/// # use angulus::Angle;
+/// let a = Angle::from_degrees(90.0);
+/// let b = Angle::from_degrees(450.0);
+///
+/// assert_eq!(a, b);
+/// ```
+///
+/// To preserve the difference use [`AngleUnbounded`].
+///
+/// ## Why does it doesn't implement [`PartialOrd`] ?
+///
+/// Because [`Angle`]s represents points on the circle (i.e. not a numerical value), they cannot be ordered.
+///
+/// ## The main range
+///
+/// The main range for an angle is :
+///
+/// - `(-π, π]` radians
+/// - `(-180, 180]` degrees
+/// - `(-0.5, 0.5]` turns
+/// - `(-200, 200]` gradians
+///
 #[derive(Copy, Clone, PartialEq, Eq, Hash)]
 #[repr(transparent)]
 pub struct Angle<F> {
@@ -160,6 +186,8 @@ impl<F: Float> Angle<F> {
 
 impl<F: Copy> Angle<F> {
     /// The value of the angle in radians.
+    ///
+    /// This value is in the range `(-π, π]`.
     #[inline]
     pub const fn to_radians(self) -> F {
         self.radians
@@ -168,18 +196,24 @@ impl<F: Copy> Angle<F> {
 
 impl<F: Float> Angle<F> {
     /// The value of the angle in degrees.
+    ///
+    /// This value is in the range `(-180, 180]`.
     #[inline]
     pub fn to_degrees(self) -> F {
         self.radians * F::RAD_TO_DEG
     }
 
     /// The value of the angle in turns.
+    ///
+    /// This value is in the range `(-0.5, 0.5]`.
     #[inline]
     pub fn to_turns(self) -> F {
         self.radians * F::RAD_TO_TURNS
     }
 
     /// The value of the angle in gradians.
+    ///
+    /// This value is in the range `(-200, 200]`.
     #[inline]
     pub fn to_gradians(self) -> F {
         self.radians * F::RAD_TO_GRAD
@@ -191,7 +225,7 @@ impl<F: Float> Angle<F> {
 //-------------------------------------------------------------------
 
 impl<F: Copy> Angle<F> {
-    /// Converts this angle into an unbounded angle.
+    /// Converts this angle into an unbounded angle in [the main range](Angle#the-main-range).
     pub const fn to_unbounded(self) -> AngleUnbounded<F> {
         AngleUnbounded::from_radians(self.radians)
     }

--- a/src/angle.rs
+++ b/src/angle.rs
@@ -23,7 +23,7 @@ use crate::{
 ///
 /// To preserve the difference use [`AngleUnbounded`].
 ///
-/// ## Why does it doesn't implement [`PartialOrd`] ?
+/// ## Why doesn't it implement [`PartialOrd`] ?
 ///
 /// Because [`Angle`]s represents points on the circle (i.e. not a numerical value), they cannot be ordered.
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,30 +10,28 @@
 //!
 //! [`Angle`] and [`AngleUnbounded`] represent an angle value with no specific unit.
 //!
-//! [`Angle`] represent a canonical angle, i.e. the internal value fit the range `(-π, π]` in radians.
+//! ## [`Angle`] vs [`AngleUnbounded`]
 //!
-//! For example, `90°` and `-270°` have different value but are the same angle.
+//! Both represent a point on the circle as a unit agnostic angle.
+//!
+//! But [`Angle`] considere two different values of the same point as the same angle :
 //!
 //! ```
 //! # use angulus::Angle;
-//! # fn main() {
 //! let a = Angle::from_degrees(90.0);
-//! let b = Angle::from_degrees(-270.0);
+//! let b = Angle::from_degrees(450.0);
 //!
 //! assert_eq!(a, b);
-//! # }
 //! ```
 //!
-//! Conversely [`AngleUnbounded`] represent any angle value.
+//! While [`AngleUnbounded`] considere those value as two different angle :
 //!
 //! ```
 //! # use angulus::AngleUnbounded;
-//! # fn main() {
 //! let a = AngleUnbounded::from_degrees(90.0);
-//! let b = AngleUnbounded::from_degrees(-270.0);
+//! let b = AngleUnbounded::from_degrees(450.0);
 //!
 //! assert_ne!(a, b);
-//! # }
 //! ```
 //!
 //! ## From value to angle
@@ -42,24 +40,20 @@
 //!
 //! ```
 //! # use angulus::*;
-//! # fn main() {
 //! let deg = Angle::from_degrees(90.0);
 //! let rad = Angle::from_radians(3.14);
 //! let turns = Angle::from_turns(0.75);
 //! let grad = Angle::from_gradians(50.0);
-//! # }
 //! ```
 //!
 //! or you use the [`ToAngle`] trait directly on the value.
 //!
 //! ```
 //! # use angulus::*;
-//! # fn main() {
 //! let deg = 90.0.deg();
 //! let rad = 3.14.rad();
 //! let turns = 0.75.turns();
 //! let grad = 50.0.grad();
-//! # }
 //! ```
 //!
 //! ## From angle to value
@@ -68,14 +62,12 @@
 //!
 //! ```
 //! # use angulus::*;
-//! # fn main() {
 //! let a = Angle32::QUARTER;
 //!
 //! assert_eq!(a.to_radians(), std::f32::consts::FRAC_PI_2);
 //! assert_eq!(a.to_degrees(), 90.0);
 //! assert_eq!(a.to_turns(), 0.25);
 //! assert_eq!(a.to_gradians(), 100.0);
-//! # }
 //! ```
 //!
 //! ## Display

--- a/src/rand.rs
+++ b/src/rand.rs
@@ -6,10 +6,10 @@
 //! with the [`Standard`] distribution, and so with [`rand::random`](https://docs.rs/rand/latest/rand/fn.random.html) with the following
 //! ranges and distributions:
 //!
-//! - [`Angle`]: Uniformly distributed on the full circle.
+//! - [`Angle`]: Uniformly distributed on the circle.
 //! - [`AngleUnbounded`]: Uniformly distributed in the range `(-π, π]` radians.
 //!
-//! **Note**: The unit wrapper has no influence on the generated value.
+//! **Note**: The unit wrappers have no influence on the generated value.
 //!
 //! ## Uniform ranges
 //!
@@ -17,7 +17,7 @@
 //!
 //! ### [`Angle`]
 //!
-//! Because [`Angle`] did not implements [`PartialOrd`], the generated angle will belong to the part of the
+//! Because [`Angle`] [did not implements `PartialOrd`](crate::angle::Angle#why-does-it-doesnt-implement-partialord-), the generated angle will belong to the part of the
 //! circle between the bounds in counterclockwise. I.e. the order of the bounds will determine
 //! which part of the circle the generated angle belongs to.
 //!

--- a/src/rand.rs
+++ b/src/rand.rs
@@ -17,7 +17,7 @@
 //!
 //! ### [`Angle`]
 //!
-//! Because [`Angle`] [did not implements `PartialOrd`](crate::angle::Angle#why-does-it-doesnt-implement-partialord-), the generated angle will belong to the part of the
+//! Because [`Angle`] [did not implements `PartialOrd`](Angle#why-doesnt-it-implement-partialord-), the generated angle will belong to the part of the
 //! circle between the bounds in counterclockwise. I.e. the order of the bounds will determine
 //! which part of the circle the generated angle belongs to.
 //!

--- a/src/rand.rs
+++ b/src/rand.rs
@@ -3,8 +3,8 @@
 //! ## Provided implementations
 //!
 //! [`Angle`] and [`AngleUnbounded`] (and [their unit wrapped equivalent][crate::units]) can be generated
-//! with the [`Standard`] distribution, and so with [`rand::random`](https://docs.rs/rand/latest/rand/fn.random.html) with the following
-//! ranges and distributions:
+//! with the [`Standard`] distribution, and so with [`rand::random`](https://docs.rs/rand/latest/rand/fn.random.html)
+//! with the following ranges and distributions:
 //!
 //! - [`Angle`]: Uniformly distributed on the circle.
 //! - [`AngleUnbounded`]: Uniformly distributed in the range `(-π, π]` radians.
@@ -17,9 +17,9 @@
 //!
 //! ### [`Angle`]
 //!
-//! Because [`Angle`] [did not implements `PartialOrd`](Angle#why-doesnt-it-implement-partialord-), the generated angle will belong to the part of the
-//! circle between the bounds in counterclockwise. I.e. the order of the bounds will determine
-//! which part of the circle the generated angle belongs to.
+//! Because [`Angle`] [did not implements `PartialOrd`](Angle#why-doesnt-it-implement-partialord-),
+//! the generated angle will belong to the part of the circle between the bounds in counterclockwise.
+//! I.e. the order of the bounds will determine which part of the circle the generated angle belongs to.
 //!
 //! ```
 //! # use angulus::*;

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -6,11 +6,12 @@
 //! To explicitly (de)serialize to/from a specific unit, you can wrap the angle type into a unit wrapper from
 //! [the units module][crate::units].
 //!
+//! [`Angle`] (and their wrapped equivalents) will serialize to a value in [the main range](Angle#the-main-range).
+//!
 //! ```
 //! # use angulus::{units::*, *};
 //! # use float_eq::assert_float_eq;
 //! # use ::serde::{Serialize, Deserialize};
-//! # fn main() {
 //! #[derive(Serialize, Deserialize)]
 //! struct Foo {
 //!     angle: Angle32,
@@ -37,7 +38,6 @@
 //! assert_float_eq!(foo.deg.0.to_degrees(), 90.0, abs <= 0.000001);
 //! assert_float_eq!(foo.tr.0.to_turns(), 0.5, abs <= 0.000001);
 //! assert_float_eq!(foo.grad.0.to_gradians(), 50.0, abs <= 0.000001);
-//! # }
 //! ```
 
 use serde::{Deserialize, Serialize};

--- a/src/unbounded.rs
+++ b/src/unbounded.rs
@@ -5,23 +5,22 @@ use std::{
 
 use crate::{float::Float, forward_ref_binop, forward_ref_op_assign, forward_ref_unop, Angle};
 
-/// Represents an angle that may not be the canonical value.
-///
-/// The value of this angle is not bound into a range, unlike [`Angle`].
-///
-/// ```
-/// # use angulus::*;
-/// # use float_eq::assert_float_eq;
-/// # fn main() {
-/// let angle = (3.0_f32 * 90.0_f32.deg()).to_degrees();
-/// let unbounded = (3.0_f32 * 90.0_f32.deg_unbounded()).to_degrees();
-///
-/// assert_float_eq!(angle, -90.0, ulps <= 1);
-/// assert_float_eq!(unbounded, 270.0, ulps <= 1);
-/// # }
-/// ```
+/// Represents a point on the circle as an unit agnostic angle.
 ///
 /// The parameter `F` is the floating-point type used to store the value.
+///
+/// ## Behaviour
+/// Unlike [`Angle`], two different values of the same point on the circle are different
+/// angles :
+///
+/// ```
+/// # use angulus::AngleUnbounded;
+/// let a = AngleUnbounded::from_degrees(90.0);
+/// let b = AngleUnbounded::from_degrees(450.0);
+///
+/// assert_ne!(a, b);
+/// ```
+
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Hash)]
 #[repr(transparent)]
 pub struct AngleUnbounded<F> {

--- a/src/units.rs
+++ b/src/units.rs
@@ -9,14 +9,12 @@
 //!
 //! ```
 //! # use angulus::{Angle, ToAngle, units::{Degrees, Radians, Turns, Gradians}};
-//! # fn main() {
 //! let angle = 90.0_f32.deg();
 //!
 //! assert_eq!(format!("{}", Radians(angle)), "1.5707964 rad");
 //! assert_eq!(format!("{}", Degrees(angle)), "90°");
 //! assert_eq!(format!("{}", Turns(angle)), "0.25 tr");
 //! assert_eq!(format!("{}", Gradians(angle)), "100g");
-//! # }
 //! ```
 
 use std::fmt::Display;

--- a/src/units.rs
+++ b/src/units.rs
@@ -7,6 +7,8 @@
 //! But unit wrappers implement the [`Display`] trait.
 //! The value is displayed by writting the angle value in the desired unit followed by the unit symbole.
 //!
+//! For [`Angle`], the displayed value is in [the main range](Angle#the-main-range).
+//!
 //! ```
 //! # use angulus::{Angle, ToAngle, units::{Degrees, Radians, Turns, Gradians}};
 //! let angle = 90.0_f32.deg();
@@ -36,6 +38,8 @@ macro_rules! unit {
         impl<F: Float> $name<Angle<F>> {
             /// The value of the angle in
             #[doc = $unit]
+            ///
+            /// The value is in [the main range](Angle#the-main-range).
             #[inline]
             pub fn to_value(self) -> F {
                 self.0.$to_method()


### PR DESCRIPTION
- Clarify angle types behaviour.
- Add a note about the main range.
- Explain why `Angle` cannot be `PartialOrd`.