### PR TITLE
Add a prelude module

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Using simple floating point numbers to store an angle value is error-prone : you
 ## Example
 
 ```rust
-use angulus::*;
+use angulus::prelude::*;
 
 // Create an angle of 90°.
 let alpha = 90.0_f32.deg();
@@ -28,8 +28,8 @@ let gamma = alpha + beta;
 // Print the result.
 println!(
     "The cosine of {} is {}",
-    units::Degrees(gamma), // The angle is wrapped to display the value in degrees.
-    gamma.cos()            // Compute the cosine without worrying about units.
+    Degrees(gamma), // The angle is wrapped to display the value in degrees.
+    gamma.cos()     // Compute the cosine without worrying about units.
 );
 
 // Output : The cosine of 135° is -0.70710677

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,7 +39,7 @@
 //! To create an angle from a value, you can use the `from_*` methods with the unit of the value...
 //!
 //! ```
-//! # use angulus::*;
+//! # use angulus::Angle;
 //! let deg = Angle::from_degrees(90.0);
 //! let rad = Angle::from_radians(3.14);
 //! let turns = Angle::from_turns(0.75);
@@ -49,7 +49,7 @@
 //! or you use the [`ToAngle`] trait directly on the value.
 //!
 //! ```
-//! # use angulus::*;
+//! # use angulus::ToAngle;
 //! let deg = 90.0.deg();
 //! let rad = 3.14.rad();
 //! let turns = 0.75.turns();
@@ -61,7 +61,7 @@
 //! To convert back an angle to a value you can use the `to_*` methods with the desired unit.
 //!
 //! ```
-//! # use angulus::*;
+//! # use angulus::Angle32;
 //! let a = Angle32::QUARTER;
 //!
 //! assert_eq!(a.to_radians(), std::f32::consts::FRAC_PI_2);
@@ -113,3 +113,16 @@ pub type AngleUnbounded32 = AngleUnbounded<f32>;
 
 /// Type alias for [`AngleUnbounded::<f64>`].
 pub type AngleUnbounded64 = AngleUnbounded<f64>;
+
+/// Re-exports the most important elements of the crate.
+///
+/// ## Usage
+/// ```
+/// use angulus::prelude::*;
+/// ```
+pub mod prelude {
+    pub use crate::{
+        units::*, Angle, Angle32, Angle64, AngleUnbounded, AngleUnbounded32, AngleUnbounded64,
+        ToAngle,
+    };
+}


### PR DESCRIPTION
**Problem**: Using `use angulus::*` shadows name like `serde` or `rand`.
**Solution**: Add a prelude module that re-exports only important elements.