### PR TITLE
Document the `Angle(NaN)` case 

### DIFF
--- a/src/angle.rs
+++ b/src/angle.rs
@@ -173,6 +173,7 @@ impl<F: Float> Angle<F> {
     /// the the range `[-2π, 2π]`.
     #[inline]
     fn from_radians_partially_unchecked(radians: F) -> Self {
+        debug_assert!(-F::TAU <= radians && radians <= F::TAU);
         let radians = if radians > F::PI {
             radians - F::TAU
         } else if radians <= -F::PI {

--- a/src/angle.rs
+++ b/src/angle.rs
@@ -173,7 +173,7 @@ impl<F: Float> Angle<F> {
     /// the the range `[-2π, 2π]`.
     #[inline]
     fn from_radians_partially_unchecked(radians: F) -> Self {
-        debug_assert!(-F::TAU <= radians && radians <= F::TAU);
+        debug_assert!(radians.is_nan() || (-F::TAU <= radians && radians <= F::TAU));
         let radians = if radians > F::PI {
             radians - F::TAU
         } else if radians <= -F::PI {

--- a/src/angle.rs
+++ b/src/angle.rs
@@ -37,6 +37,38 @@ use crate::{
 /// - `(-0.5, 0.5]` turns
 /// - `(-200, 200]` gradians
 ///
+/// ## The `NaN` angle
+///
+/// An angle can be `NaN` in the following cases :
+///
+/// - create the angle from an non finite value
+/// ```
+/// # use angulus::Angle;
+/// let a = Angle::from_radians(f32::INFINITY);
+/// assert!(a.is_nan());
+///
+/// let b = Angle::from_radians(f32::NAN);
+/// assert!(b.is_nan());
+/// ```
+/// - create the angle with a too big value
+/// ```
+/// # use angulus::Angle;
+/// // Some unit can handle big values ...
+/// let a = Angle::from_degrees(f32::MAX);
+/// assert!(!a.is_nan());
+///
+/// // but not all.
+/// let b = Angle::from_turns(f32::MAX);
+/// assert!(b.is_nan());
+/// ```
+/// - doing some operations that result into non finite value
+/// ```
+/// # use angulus::Angle;
+/// let a = Angle::DEG_90;
+/// let b = a / 0.0;
+///
+/// assert!(b.is_nan());
+/// ```
 #[derive(Copy, Clone, PartialEq, Eq, Hash)]
 #[repr(transparent)]
 pub struct Angle<F> {
@@ -218,6 +250,16 @@ impl<F: Float> Angle<F> {
     #[inline]
     pub fn to_gradians(self) -> F {
         self.radians * F::RAD_TO_GRAD
+    }
+}
+
+impl<F: Float> Angle<F> {
+    /// Returns `true` if this angle is NaN.
+    ///
+    /// See [`Angle` documentation][Angle] for more details.
+    #[inline]
+    pub fn is_nan(self) -> bool {
+        self.radians.is_nan()
     }
 }
 

--- a/src/angle.rs
+++ b/src/angle.rs
@@ -291,7 +291,10 @@ impl Angle<f32> {
     #[inline]
     pub fn to_f64(self) -> Angle<f64> {
         let radians = self.radians as f64;
-        debug_assert!(-std::f64::consts::PI < radians && radians <= std::f64::consts::PI);
+        debug_assert!(
+            radians.is_nan()
+                || (-std::f64::consts::PI < radians && radians <= std::f64::consts::PI)
+        );
         // Notes: f32 to f64 convertion is losslessly, we don't need to check the range.
         Angle::from_radians_unchecked(radians)
     }
@@ -461,7 +464,7 @@ impl<F: Float> Neg for Angle<F> {
 
     #[inline]
     fn neg(self) -> Self::Output {
-        debug_assert!(-F::PI < self.radians && self.radians <= F::PI);
+        debug_assert!(self.radians.is_nan() || (-F::PI < self.radians && self.radians <= F::PI));
         if self.radians == F::PI {
             self
         } else {

--- a/src/float.rs
+++ b/src/float.rs
@@ -76,6 +76,9 @@ pub trait Float:
     /// Convertion factor from radians to gradians.
     const RAD_TO_GRAD: Self;
 
+    /// The value of τ radians in turns.
+    const TAU_RAD_IN_TURNS: Self;
+
     /// Returns `true` if this value is NaN.
     fn is_nan(self) -> bool;
 
@@ -111,6 +114,8 @@ impl Float for f32 {
 
     const GRAD_TO_RAD: Self = std::f32::consts::PI / 200.0;
     const RAD_TO_GRAD: Self = 200.0 / std::f32::consts::PI;
+
+    const TAU_RAD_IN_TURNS: Self = Self::TAU * Self::RAD_TO_TURNS;
 
     #[inline]
     fn is_nan(self) -> bool {
@@ -160,6 +165,8 @@ impl Float for f64 {
 
     const GRAD_TO_RAD: Self = std::f64::consts::PI / 200.0;
     const RAD_TO_GRAD: Self = 200.0 / std::f64::consts::PI;
+
+    const TAU_RAD_IN_TURNS: Self = Self::TAU * Self::RAD_TO_TURNS;
 
     #[inline]
     fn is_nan(self) -> bool {

--- a/src/float.rs
+++ b/src/float.rs
@@ -76,6 +76,9 @@ pub trait Float:
     /// Convertion factor from radians to gradians.
     const RAD_TO_GRAD: Self;
 
+    /// Returns `true` if this value is NaN.
+    fn is_nan(self) -> bool;
+
     /// Computes the sine (in radians).
     fn sin(self) -> Self;
     /// Computes the cosine (in radians).
@@ -108,6 +111,11 @@ impl Float for f32 {
 
     const GRAD_TO_RAD: Self = std::f32::consts::PI / 200.0;
     const RAD_TO_GRAD: Self = 200.0 / std::f32::consts::PI;
+
+    #[inline]
+    fn is_nan(self) -> bool {
+        self.is_nan()
+    }
 
     #[inline]
     fn sin(self) -> Self {
@@ -152,6 +160,11 @@ impl Float for f64 {
 
     const GRAD_TO_RAD: Self = std::f64::consts::PI / 200.0;
     const RAD_TO_GRAD: Self = 200.0 / std::f64::consts::PI;
+
+    #[inline]
+    fn is_nan(self) -> bool {
+        self.is_nan()
+    }
 
     #[inline]
     fn sin(self) -> Self {


### PR DESCRIPTION
- Add a section in doc to indicate that `Angle` can be `NaN`.
- Also add a `is_nan` method.
- fix : `Angle::from_turns` will no more returns `NaN` if the provided value is too large.