### PR TITLE
Remove the `prelude` module

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ Using simple floating point numbers to store an angle value is error-prone : you
 ## Example
 
 ```rust
-use angulus::prelude::*;
+use angulus::{Angle, ToAngle};
+use angulus::units::Degrees;
 
 // Create an angle of 90°.
 let alpha = 90.0_f32.deg();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -119,16 +119,3 @@ pub type AngleUnbounded32 = AngleUnbounded<f32>;
 
 /// Type alias for [`AngleUnbounded::<f64>`].
 pub type AngleUnbounded64 = AngleUnbounded<f64>;
-
-/// Re-exports the most important elements of the crate.
-///
-/// # Usage
-/// ```
-/// use angulus::prelude::*;
-/// ```
-pub mod prelude {
-    pub use crate::units::*;
-    pub use crate::{
-        Angle, Angle32, Angle64, AngleUnbounded, AngleUnbounded32, AngleUnbounded64, ToAngle,
-    };
-}


### PR DESCRIPTION
This module is useless since most of the type are already export at crate level.