### PR TITLE
Remove `Float::TAU_RAD_IN_TURNS`

### DIFF
--- a/src/angle.rs
+++ b/src/angle.rs
@@ -201,7 +201,7 @@ impl<F: Float> Angle<F> {
     pub fn from_turns(turns: F) -> Self {
         // NOTE: to avoid `NaN` when handling big values, we have to operate the REM before
         // converting the value into radians.
-        Self::from_radians_partially_unchecked((turns % F::TAU_RAD_IN_TURNS) * F::TURNS_TO_RAD)
+        Self::from_radians_partially_unchecked((turns % F::ONE) * F::TURNS_TO_RAD)
     }
 
     /// Creates a new angle from a value in gradians.

--- a/src/float.rs
+++ b/src/float.rs
@@ -76,9 +76,6 @@ pub trait Float:
     /// Convertion factor from radians to gradians.
     const RAD_TO_GRAD: Self;
 
-    /// The value of τ radians in turns.
-    const TAU_RAD_IN_TURNS: Self;
-
     /// Returns `true` if this value is NaN.
     fn is_nan(self) -> bool;
 }
@@ -121,8 +118,6 @@ impl Float for f32 {
     const GRAD_TO_RAD: Self = core::f32::consts::PI / 200.0;
     const RAD_TO_GRAD: Self = 200.0 / core::f32::consts::PI;
 
-    const TAU_RAD_IN_TURNS: Self = Self::TAU * Self::RAD_TO_TURNS;
-
     #[inline]
     fn is_nan(self) -> bool {
         self.is_nan()
@@ -151,8 +146,6 @@ impl Float for f64 {
 
     const GRAD_TO_RAD: Self = core::f64::consts::PI / 200.0;
     const RAD_TO_GRAD: Self = 200.0 / core::f64::consts::PI;
-
-    const TAU_RAD_IN_TURNS: Self = Self::TAU * Self::RAD_TO_TURNS;
 
     #[inline]
     fn is_nan(self) -> bool {


### PR DESCRIPTION
`Float::TAU_RAD_IN_TURNS` is redundant with `Float::ONE`.